### PR TITLE
P22-802 : Added option to setup dependencies with Poetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # Setup Python GitHub Action
 
-Setup Python environment with Pipenv and cache the virtual environment.
+Setup Python environment and cache the virtual environment.
+
+Dependencies manager Pipenv or Poetry can be used. 
+Projects using Poetry must specify version in `.tool-versions`.

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,8 @@
-name: Install Python dependencies with Pipenv and caching.
+name: Install Python dependencies with Pipenv or Poetry and caching.
 description: |
-  Install Python dependencies with Pipenv.
+  Install Python dependencies and caching. |
+  Dependencies manager Pipenv or Poetry is detetected using file `.tool-versions`. |
+  Caching name is defined.
 
 runs:
   using: composite
@@ -10,16 +12,51 @@ runs:
       shell: bash
       run: echo "python-version=$(cat .tool-versions | grep python | awk '{print $2}')" >> $GITHUB_OUTPUT
 
-    - name: Install pipenv
+    - name: Search Poetry
+      id: search-poetry
       shell: bash
+      run: echo "poetry-str=$(cat .tool-versions | grep poetry | awk '{print $1}')" >> $GITHUB_OUTPUT
+
+    - name: Check if poetry
+      id: check-if-poetry
+      shell: bash
+      run: echo "use-poetry=$(expr '${{ steps.search-poetry.outputs.poetry-str }}' == 'poetry')" >> $GITHUB_OUTPUT
+
+    - name: Get poetry version
+      id: get-poetry-version
+      shell: bash
+      if: ${{ steps.check-if-poetry.outputs.use-poetry == 1 }}
+      run: echo "poetry-version=$(cat .tool-versions | grep poetry | awk '{print $2}')" >> $GITHUB_OUTPUT
+
+    - name: Install poetry if selected
+      id: install-poetry-if-selected
+      shell: bash
+      if: ${{ steps.check-if-poetry.outputs.use-poetry == 1 }}
+      run: pipx install poetry==${{ steps.get-poetry-version.outputs.poetry-version }}
+
+    - name: Install pipenv if not poetry
+      id: install-pipenv-if-not-poetry
+      shell: bash
+      if: ${{ steps.check-if-poetry.outputs.use-poetry != 1 }}
       run: pipx install pipenv
+
+    - name: Get cache name
+      id: get-cache-name
+      shell: bash
+      run: if [[ ${{ steps.check-if-poetry.outputs.use-poetry }} == 1 ]]; then echo 'cache=poetry'; else echo 'cache=pipenv'; fi >> $GITHUB_OUTPUT
 
     - name: Setup Python environment and cache
       uses: actions/setup-python@v4
       with:
         python-version: ${{ steps.get-python-version.outputs.python-version }}
-        cache: 'pipenv'
+        cache: ${{ steps.get-cache-name.outputs.cache }}
 
-    - name: Install dependencies
+    - name: Install dependencies using poetry
       shell: bash
+      if: ${{ steps.check-if-poetry.outputs.use-poetry == 1 }}
+      run: poetry install --sync
+
+    - name: Install dependencies using pipenv
+      shell: bash
+      if: ${{ steps.check-if-poetry.outputs.use-poetry != 1 }}
       run: pipenv sync --dev

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,11 @@ description: |
   Dependencies manager Pipenv or Poetry is detetected using file `.tool-versions`. |
   Caching name is defined.
 
+outputs:
+  dependencies-manager:
+    description: "Dependencies manager selection between 'pipenv' and 'poetry'."
+    value: ${{ steps.dependencies-manager.outputs.dm }}
+
 runs:
   using: composite
   steps:
@@ -21,6 +26,11 @@ runs:
       id: check-if-poetry
       shell: bash
       run: echo "use-poetry=$(expr '${{ steps.search-poetry.outputs.poetry-str }}' == 'poetry')" >> $GITHUB_OUTPUT
+
+    - name: Dependecies Manager
+      id: dependencies-manager
+      shell: bash
+      run: if [[ ${{ steps.check-if-poetry.outputs.use-poetry }} == 1 ]]; then echo 'dm=poetry'; else echo 'dm=pipenv'; fi >> $GITHUB_OUTPUT
 
     - name: Get poetry version
       id: get-poetry-version


### PR DESCRIPTION
Je propose d'ajouter l'option d'utiliser le gestionnaire de dépendances Poetry. 
Le setup avec Pipenv reste disponible pour les projets qui l'utilise toujours.

Avant d'installer les dépendances, on vient détecter si Poetry est utilisé dans `.tool-versions`. S'il est présent, on fait le setup pour Poetry, sinon on fait le setup pour Pipenv.

J'ai fait des essais avec des branches utilisant Poetry et des branches utilisant Pipenv, tout semble fonctionnel.

Il ne resterait qu'à mettre à jour aussi le projet [python-workflows](https://github.com/equisoft-actions/python-workflows) pour utiliser Poetry. En attendant cette mise à jour Pipenv reste utilisable sans modifications aux autres projets, ce n'est pas un breaking change.

